### PR TITLE
Correct API types for revisionList properties

### DIFF
--- a/ecobee/functions.go
+++ b/ecobee/functions.go
@@ -154,31 +154,15 @@ func (c *Client) GetThermostatSummary(selection Selection) (map[string]Thermosta
 		if err != nil {
 			return nil, fmt.Errorf("error from ParseBool(%v): %v", rl[2], err)
 		}
-		thermostatRevision, err := strconv.Atoi(rl[3])
-		if err != nil {
-			return nil, fmt.Errorf("error Atoi(%v): %v", rl[3], err)
-		}
-		alertsRevision, err := strconv.Atoi(rl[4])
-		if err != nil {
-			return nil, fmt.Errorf("error Atoi(%v): %v", rl[4], err)
-		}
-		runtimeRevision, err := strconv.Atoi(rl[5])
-		if err != nil {
-			return nil, fmt.Errorf("error Atoi(%v): %v", rl[5], err)
-		}
-		intervalRevision, err := strconv.Atoi(rl[6])
-		if err != nil {
-			return nil, fmt.Errorf("error Atoi(%v): %v", rl[6], err)
-		}
 
 		ts := ThermostatSummary{
 			Identifier:         rl[0],
 			Name:               rl[1],
 			Connected:          connected,
-			ThermostatRevision: thermostatRevision,
-			AlertsRevision:     alertsRevision,
-			RuntimeRevision:    runtimeRevision,
-			IntervalRevision:   intervalRevision,
+			ThermostatRevision: rl[3],
+			AlertsRevision:     rl[4],
+			RuntimeRevision:    rl[5],
+			IntervalRevision:   rl[6],
 			EquipmentStatus:    es,
 		}
 		tsm[rl[0]] = ts

--- a/ecobee/objects.go
+++ b/ecobee/objects.go
@@ -284,10 +284,10 @@ type ThermostatSummary struct {
 	Identifier         string `json:"Identifier"`
 	Name               string `json:"Name"`
 	Connected          bool   `json:"Connected"`
-	ThermostatRevision int    `json:"ThermostatRevision"`
-	AlertsRevision     int    `json:"AlertsRevision."`
-	RuntimeRevision    int    `json:"RuntimeRevision"`
-	IntervalRevision   int    `json:"IntervalRevision"`
+	ThermostatRevision string `json:"ThermostatRevision"`
+	AlertsRevision     string `json:"AlertsRevision."`
+	RuntimeRevision    string `json:"RuntimeRevision"`
+	IntervalRevision   string `json:"IntervalRevision"`
 	EquipmentStatus
 }
 type ThermostatSummaryMap map[string]ThermostatSummary

--- a/ecobee/objects.go
+++ b/ecobee/objects.go
@@ -285,7 +285,7 @@ type ThermostatSummary struct {
 	Name               string `json:"Name"`
 	Connected          bool   `json:"Connected"`
 	ThermostatRevision string `json:"ThermostatRevision"`
-	AlertsRevision     string `json:"AlertsRevision."`
+	AlertsRevision     string `json:"AlertsRevision"`
 	RuntimeRevision    string `json:"RuntimeRevision"`
 	IntervalRevision   string `json:"IntervalRevision"`
 	EquipmentStatus


### PR DESCRIPTION
The API specifies string types for the revision properties. This also fixes 32-bit platform operation, e.g. Raspberry Pi.