### PR TITLE
Fix status command to show current climateRef

### DIFF
--- a/ecobee/functions.go
+++ b/ecobee/functions.go
@@ -72,7 +72,7 @@ func (c *Client) GetThermostat(thermostatID string) (*Thermostat, error) {
 
 		IncludeAlerts:          false,
 		IncludeEvents:          true,
-		IncludeProgram:         false,
+		IncludeProgram:         true,
 		IncludeRuntime:         true,
 		IncludeExtendedRuntime: false,
 		IncludeSettings:        false,


### PR DESCRIPTION
This is kind of a dumb change, but it fixes the demo CLI tool, which would show Current Settings () instead of Current Settings (Home), for example.

I'm kind of stumbling my way through the API, trying to discover how to make it useful. I was hoping to integrate the thermostat with my home alarm system, using the alarm as a source of occupancy information, but it seems that's not possible. I guess instead I'll have to have it set a hold using the "away" climateRef when away, and resume when present, and remove away from all the schedules. If you have any alternative suggestions, I'd be very appreciative!