### PR TITLE
Add fields to Runtime based on returns from my thermostat

### DIFF
--- a/ecobee/objects.go
+++ b/ecobee/objects.go
@@ -171,11 +171,17 @@ type Runtime struct {
 	RuntimeInterval    int    `json:"runtimeInterval"`
 	ActualTemperature  int    `json:"actualTemperature"`
 	ActualHumidity     int    `json:"actualHumidity"`
+	RawTemperature     int    `json:"rawTemperature"`
+	ShowIconMode       int    `json:"showIconMode"`
 	DesiredHeat        int    `json:"desiredHeat"`
 	DesiredCool        int    `json:"desiredCool"`
 	DesiredHumidity    int    `json:"desiredHumidity"`
 	DesiredDehumidity  int    `json:"desiredDehumidity"`
 	DesiredFanMode     string `json:"desiredFanMode"`
+	ActualVOC          int    `json:"actualVOC"`
+	ActualCO2          int    `json:"actualCO2"`
+	ActualAQAccuracy   int    `json:"actualAQAccuracy"`
+	ActualAQScore      int    `json:"actualAQScore"`
 	DesiredHeatRange   []int  `json:"desiredHeatRange"`
 	DesiredCoolRange   []int  `json:"desiredCoolRange"`
 }


### PR DESCRIPTION
These fields show up when I send a request to `https://api.ecobee.com/1/thermostat`, and I'd love to get that data.