### PR TITLE
Fix urls & add developer enablement guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-ecobee
 
 A go library and simple tools for accessing the
-[Ecobee Thermostat API](https://www.ecobee.com/home/developer/api/documentation/v1).
+[Ecobee Thermostat API](https://www.ecobee.com/home/developer/api/documentation/v1/index.shtml).
 
 The go-ecobee CLI is built with the underlying go-ecobee API, and
 serves as it's primary example.
@@ -25,8 +25,10 @@ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main
 
 ### Application ID
 
-Create an Ecobee API Application ID (API key) at
-https://www.ecobee.com/consumerportal/index.html#/dev
+[Enable your developer dashboard](https://www.ecobee.com/home/developer/loginDeveloper.jsp), if you have not already.
+
+Create an Ecobee API Application ID (API key) by going to the
+[consumer portal](https://www.ecobee.com/consumerportal/index.html), clicking the "Developer" option in the menu, and clicking the "Create New" button.
 
 You probably want to use the `ecobee PIN` authorization method for non-web based
 tools.


### PR DESCRIPTION
2 of the URLs did not work and it was a little confusing how to enable the developer options. So, this fixes the url references and adds the direct link for enabling the developer menu option.