### PR TITLE
Add SelectionOptions type and refactor GetThermostat to use them

### DIFF
--- a/ecobee/functions.go
+++ b/ecobee/functions.go
@@ -26,10 +26,9 @@ import (
 	"github.com/golang/glog"
 )
 
-const (
-	thermostatAPIURL     = `https://api.ecobee.com/1/thermostat`
-	thermostatSummaryURL = `https://api.ecobee.com/1/thermostatSummary`
-)
+const thermostatAPIURL     = `https://api.ecobee.com/1/thermostat`
+const thermostatSummaryURL = `https://api.ecobee.com/1/thermostatSummary`
+
 
 func (c *Client) UpdateThermostat(utr UpdateThermostatRequest) error {
 	j, err := json.Marshal(&utr)
@@ -82,8 +81,8 @@ func (c *Client) GetThermostat(thermostatID string, opts ...SelectionOption) (*T
 		IncludeWeather:         false,
 	}
 
-	for _, optfn := range opts {
-		optfn(s)
+	for _, o := range opts {
+		o(s)
 	}
 
 	thermostats, err := c.GetThermostats(s)
@@ -143,7 +142,7 @@ func (c *Client) GetThermostatSummary(selection Selection) (map[string]Thermosta
 
 	glog.V(1).Infof("GetThermostatSummary response: %#v", r)
 
-	tsm := make(ThermostatSummaryMap, r.ThermostatCount)
+	var tsm = make(ThermostatSummaryMap, r.ThermostatCount)
 
 	for i := 0; i < r.ThermostatCount; i++ {
 		rl := strings.Split(r.RevisionList[i], ":")
@@ -178,6 +177,7 @@ func (c *Client) GetThermostatSummary(selection Selection) (map[string]Thermosta
 }
 
 func (c *Client) get(endpoint string, rawRequest []byte) ([]byte, error) {
+
 	glog.V(2).Infof("get(%s?json=%s)", endpoint, rawRequest)
 	request := url.QueryEscape(string(rawRequest))
 	resp, err := c.Get(fmt.Sprintf("%s?json=%s", endpoint, request))
@@ -226,6 +226,7 @@ func buildEquipmentStatus(input string) (EquipmentStatus, error) {
 }
 
 func (es *EquipmentStatus) Set(field string, state bool) {
+	
 	switch field {
 	case "heatPump":
 		es.HeatPump = state
@@ -258,4 +259,5 @@ func (es *EquipmentStatus) Set(field string, state bool) {
 	case "auxHotWater":
 		es.AuxHotWater = state
 	}
+
 }

--- a/ecobee/functions.go
+++ b/ecobee/functions.go
@@ -26,9 +26,8 @@ import (
 	"github.com/golang/glog"
 )
 
-const thermostatAPIURL     = `https://api.ecobee.com/1/thermostat`
+const thermostatAPIURL = `https://api.ecobee.com/1/thermostat`
 const thermostatSummaryURL = `https://api.ecobee.com/1/thermostatSummary`
-
 
 func (c *Client) UpdateThermostat(utr UpdateThermostatRequest) error {
 	j, err := json.Marshal(&utr)
@@ -226,7 +225,7 @@ func buildEquipmentStatus(input string) (EquipmentStatus, error) {
 }
 
 func (es *EquipmentStatus) Set(field string, state bool) {
-	
+
 	switch field {
 	case "heatPump":
 		es.HeatPump = state

--- a/ecobee/options.go
+++ b/ecobee/options.go
@@ -1,0 +1,135 @@
+package ecobee
+
+type SelectionOption func(s Selection)
+
+func IncludeAlerts(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeAlerts = value
+	}
+}
+
+func IncludeAudio(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeAudio = value
+	}
+}
+
+func IncludeDevice(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeDevice = value
+	}
+}
+
+func IncludeElectricity(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeElectricity = value
+	}
+}
+
+func IncludeEquipmentStatus(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeElectricity = value
+	}
+}
+
+func IncludeEvents(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeEvents = value
+	}
+}
+
+func IncludeExtendedRuntime(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeExtendedRuntime = value
+	}
+}
+
+func IncludeHouseDetails(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeHouseDetails = value
+	}
+}
+
+func IncludeLocation(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeLocation = value
+	}
+}
+
+func IncludeManagement(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeManagement = value
+	}
+}
+
+func IncludeNotificationSettings(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeManagement = value
+	}
+}
+
+func IncludeOemCfg(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeOemCfg = value
+	}
+}
+
+func IncludePrivacy(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludePrivacy = value
+	}
+}
+
+func IncludeProgram(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeProgram = value
+	}
+}
+
+func IncludeRuntime(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeRuntime = value
+	}
+}
+
+func IncludeSecuritySettings(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeSecuritySettings = value
+	}
+}
+
+func IncludeSensors(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeSensors = value
+	}
+}
+
+func IncludeSettings(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeSettings = value
+	}
+}
+
+func IncludeTechnician(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeSettings = value
+	}
+}
+
+func IncludeUtility(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeUtility = value
+	}
+}
+
+func IncludeVersion(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeVersion = value
+	}
+}
+
+func IncludeWeather(value bool) SelectionOption {
+	return func(s Selection) {
+		s.IncludeWeather = value
+	}
+}

--- a/ecobee/options.go
+++ b/ecobee/options.go
@@ -2,133 +2,133 @@ package ecobee
 
 type SelectionOption func(s Selection)
 
-func IncludeAlerts(value bool) SelectionOption {
+func WithIncludeAlerts(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeAlerts = value
 	}
 }
 
-func IncludeAudio(value bool) SelectionOption {
+func WithIncludeAudio(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeAudio = value
 	}
 }
 
-func IncludeDevice(value bool) SelectionOption {
+func WithIncludeDevice(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeDevice = value
 	}
 }
 
-func IncludeElectricity(value bool) SelectionOption {
+func WithIncludeElectricity(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeElectricity = value
 	}
 }
 
-func IncludeEquipmentStatus(value bool) SelectionOption {
+func WithIncludeEquipmentStatus(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeElectricity = value
 	}
 }
 
-func IncludeEvents(value bool) SelectionOption {
+func WithIncludeEvents(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeEvents = value
 	}
 }
 
-func IncludeExtendedRuntime(value bool) SelectionOption {
+func WithIncludeExtendedRuntime(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeExtendedRuntime = value
 	}
 }
 
-func IncludeHouseDetails(value bool) SelectionOption {
+func WithIncludeHouseDetails(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeHouseDetails = value
 	}
 }
 
-func IncludeLocation(value bool) SelectionOption {
+func WithIncludeLocation(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeLocation = value
 	}
 }
 
-func IncludeManagement(value bool) SelectionOption {
+func WithIncludeManagement(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeManagement = value
 	}
 }
 
-func IncludeNotificationSettings(value bool) SelectionOption {
+func WithIncludeNotificationSettings(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeManagement = value
 	}
 }
 
-func IncludeOemCfg(value bool) SelectionOption {
+func WithIncludeOemCfg(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeOemCfg = value
 	}
 }
 
-func IncludePrivacy(value bool) SelectionOption {
+func WithIncludePrivacy(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludePrivacy = value
 	}
 }
 
-func IncludeProgram(value bool) SelectionOption {
+func WithIncludeProgram(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeProgram = value
 	}
 }
 
-func IncludeRuntime(value bool) SelectionOption {
+func WithIncludeRuntime(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeRuntime = value
 	}
 }
 
-func IncludeSecuritySettings(value bool) SelectionOption {
+func WithIncludeSecuritySettings(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeSecuritySettings = value
 	}
 }
 
-func IncludeSensors(value bool) SelectionOption {
+func WithIncludeSensors(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeSensors = value
 	}
 }
 
-func IncludeSettings(value bool) SelectionOption {
+func WithIncludeSettings(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeSettings = value
 	}
 }
 
-func IncludeTechnician(value bool) SelectionOption {
+func WithIncludeTechnician(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeSettings = value
 	}
 }
 
-func IncludeUtility(value bool) SelectionOption {
+func WithIncludeUtility(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeUtility = value
 	}
 }
 
-func IncludeVersion(value bool) SelectionOption {
+func WithIncludeVersion(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeVersion = value
 	}
 }
 
-func IncludeWeather(value bool) SelectionOption {
+func WithIncludeWeather(value bool) SelectionOption {
 	return func(s Selection) {
 		s.IncludeWeather = value
 	}


### PR DESCRIPTION
I wanted to be able to configure GetThemostat selection data, and you have a TODO to allow for this, so I created a SelectionOption type which can be passed into GetThermostat to set specific selection options when making a request.

I modified the GetThermostat to take the options as a variadic parameter, so the change should be backwards compatible.

Originally, the option funcs were all `With<SettingName>` but that seemed redundant, so removed the With.

I can undo the formatting changes made by gofmt if you prefer.
